### PR TITLE
Adding touch event to icon

### DIFF
--- a/TouchpadOnOff@romano.rgtti.com/extension.js
+++ b/TouchpadOnOff@romano.rgtti.com/extension.js
@@ -81,6 +81,7 @@ export default class TouchpadOnOff extends Extension {
             }
         }
         this._buttonId = button.connect('button-press-event', _switch);
+        this._buttonId = button.connect('touch-event', _switch);
         this._sendId = wm_prefs.connect('changed::send-events', (s, k) => { _sync() });
         this._iconId = my_prefs.connect('changed::use-color-icons', (s, k) => { _sync() });
         // start with the current status --- sync icon

--- a/TouchpadOnOff@romano.rgtti.com/extension.js
+++ b/TouchpadOnOff@romano.rgtti.com/extension.js
@@ -81,7 +81,7 @@ export default class TouchpadOnOff extends Extension {
             }
         }
         this._buttonId = button.connect('button-press-event', _switch);
-        this._buttonId = button.connect('touch-event', _switch);
+        this._touchId = button.connect('touch-event', _switch);
         this._sendId = wm_prefs.connect('changed::send-events', (s, k) => { _sync() });
         this._iconId = my_prefs.connect('changed::use-color-icons', (s, k) => { _sync() });
         // start with the current status --- sync icon
@@ -90,6 +90,7 @@ export default class TouchpadOnOff extends Extension {
     }
     disable() {
         button.disconnect(this._buttonId);
+        button.disconnect(this._touchId);
         wm_prefs.disconnect(this._sendId);
         wm_prefs.disconnect(this._iconId);
         Main.panel._rightBox.remove_child(button);


### PR DESCRIPTION
For laptops with a touchscreen and those situation when one gets stuck with an inactive touchpad, being able to toggle the touchpad by tapping the icon on the screen seems handy. Tested on a Dell XPS 13 Plus Touchscreen, seems to work fine!